### PR TITLE
Adjust timer 0 overflow after sleep

### DIFF
--- a/RFM-basic.ino
+++ b/RFM-basic.ino
@@ -243,6 +243,7 @@ void loop() {
   os_runloop_once();
   
 #else
+  extern volatile unsigned long timer0_overflow_count;
 
   if (next == false) {
 
@@ -261,6 +262,12 @@ void loop() {
       // Enter power down state for 8 s with ADC and BOD module disabled
       LowPower.powerDown(SLEEP_8S, ADC_OFF, BOD_OFF);
       //LowPower.idle(SLEEP_8S, ADC_OFF, TIMER2_OFF, TIMER1_OFF, TIMER0_OFF, SPI_OFF, USART0_OFF, TWI_OFF);
+
+      // LMIC uses micros() to keep track of the duty cycle, so
+      // hack timer0_overflow for a rude adjustment:
+      cli();
+      timer0_overflow_count+= 8 * 64 * clockCyclesPerMicrosecond();
+      sei();
     }
     #ifdef DEBUG
       Serial.println(F("Sleep complete"));


### PR DESCRIPTION
so that the duty cycle computation is not disturbed.

Without this code when using eg SF_10 and a 32 second sleep cycle the second transmission is delayed
because the duty cycle computation is wrong, due to micros() not incrementing during sleep.